### PR TITLE
Integrate save media backend

### DIFF
--- a/Flick/Controllers/AddToListViewController.swift
+++ b/Flick/Controllers/AddToListViewController.swift
@@ -353,12 +353,12 @@ extension AddToListViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let media = searchResultMedia[indexPath.row]
-        selectMedia(SimpleMedia(id: media.id, posterPic: media.posterPic))
+        selectMedia(SimpleMedia(id: media.id, title: media.title, posterPic: media.posterPic))
     }
 
     func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
         let media = searchResultMedia[indexPath.row]
-        deselectMedia(SimpleMedia(id: media.id, posterPic: media.posterPic))
+        deselectMedia(SimpleMedia(id: media.id, title: media.title, posterPic: media.posterPic))
     }
 
 }

--- a/Flick/Controllers/MediaViewController.swift
+++ b/Flick/Controllers/MediaViewController.swift
@@ -261,3 +261,15 @@ extension MediaViewController: SaveMediaDelegate {
     }
 
 }
+
+extension MediaViewController: CreateListDelegate {
+
+    func createList(title: String) {
+        NetworkManager.createNewMediaList(listName: title, mediaIds: [mediaId]) { [weak self] mediaList in
+            guard let self = self else { return }
+
+            self.persentInfoAlert(message: "Saved to \(mediaList.name)", completion: nil)
+        }
+    }
+
+}

--- a/Flick/Controllers/MediaViewController.swift
+++ b/Flick/Controllers/MediaViewController.swift
@@ -10,6 +10,10 @@ import Foundation
 import Kingfisher
 import UIKit
 
+protocol SaveMediaDelegate: class {
+    func saveMedia(selectedList: SimpleMediaList)
+}
+
 enum CardState {case collapsed, expanded }
 
 class MediaViewController: UIViewController {
@@ -94,7 +98,7 @@ class MediaViewController: UIViewController {
                                        width: buttonSize.width, height: buttonSize.height)
         saveMediaButton.setImage(UIImage(named: "saveButton"), for: .normal)
         saveMediaButton.layer.cornerRadius = buttonSize.width / 2
-        saveMediaButton.addTarget(self, action: #selector(saveMedia), for: .touchUpInside)
+        saveMediaButton.addTarget(self, action: #selector(saveMediaTapped), for: .touchUpInside)
         view.addSubview(saveMediaButton)
 
         mediaCardViewController.view.frame = CGRect(x: 0, y: self.view.frame.height - collapsedCardHeight, width: self.view.bounds.width, height: expandedCardHeight)
@@ -123,9 +127,10 @@ class MediaViewController: UIViewController {
         navigationController?.popViewController(animated: true)
     }
 
-    @objc func saveMedia() {
+    @objc func saveMediaTapped() {
         let listsModalView = MediaListsModalView(type: .saveMedia)
         listsModalView.modalDelegate = self
+        listsModalView.saveMediaDelegate = self
         showModalPopup(view: listsModalView)
     }
 
@@ -233,6 +238,18 @@ extension MediaViewController: ModalDelegate {
 
     func dismissModal(modalView: UIView) {
         modalView.removeFromSuperview()
+    }
+
+}
+
+extension MediaViewController: SaveMediaDelegate {
+
+    func saveMedia(selectedList: SimpleMediaList) {
+        NetworkManager.addToMediaList(listId: selectedList.id, mediaIds: [mediaId]) { [weak self] list in
+            guard let self = self else { return }
+
+            self.persentInfoAlert(message: "Saved to \(selectedList.name)", completion: nil)
+        }
     }
 
 }

--- a/Flick/Controllers/MediaViewController.swift
+++ b/Flick/Controllers/MediaViewController.swift
@@ -124,7 +124,9 @@ class MediaViewController: UIViewController {
     }
 
     @objc func saveMedia() {
-        print("Save media.")
+        let listsModalView = MediaListsModalView(type: .saveMedia)
+        listsModalView.modalDelegate = self
+        showModalPopup(view: listsModalView)
     }
 
     @objc func handleAreaCardPan(recognizer: UIPanGestureRecognizer) {
@@ -223,6 +225,14 @@ extension MediaViewController: UIGestureRecognizerDelegate {
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return true
+    }
+
+}
+
+extension MediaViewController: ModalDelegate {
+
+    func dismissModal(modalView: UIView) {
+        modalView.removeFromSuperview()
     }
 
 }

--- a/Flick/Controllers/MediaViewController.swift
+++ b/Flick/Controllers/MediaViewController.swift
@@ -12,6 +12,7 @@ import UIKit
 
 protocol SaveMediaDelegate: class {
     func saveMedia(selectedList: SimpleMediaList)
+    func presentCreateNewList()
 }
 
 enum CardState {case collapsed, expanded }
@@ -250,6 +251,13 @@ extension MediaViewController: SaveMediaDelegate {
 
             self.persentInfoAlert(message: "Saved to \(selectedList.name)", completion: nil)
         }
+    }
+
+    func presentCreateNewList() {
+        let createListModal = EnterListNameModalView(type: .createList)
+        createListModal.modalDelegate = self
+        createListModal.createListDelegate = self
+        showModalPopup(view: createListModal)
     }
 
 }

--- a/Flick/Controllers/ProfileViewController.swift
+++ b/Flick/Controllers/ProfileViewController.swift
@@ -162,7 +162,7 @@ extension ProfileViewController: UITableViewDataSource, UITableViewDelegate {
 
 }
 
-extension ProfileViewController: ProfileDelegate, ModalDelegate, ListDelegate {
+extension ProfileViewController: ProfileDelegate, ModalDelegate, CreateListDelegate {
 
     func pushNotificationsView() {
         let allNotificationsViewController = AllNotificationsViewController()
@@ -172,7 +172,7 @@ extension ProfileViewController: ProfileDelegate, ModalDelegate, ListDelegate {
     func showCreateListModal() {
         let createListModalView = EnterListNameModalView(type: .createList)
         createListModalView.modalDelegate = self
-        createListModalView.listDelegate = self
+        createListModalView.createListDelegate = self
         // TODO: Revisit if having multiple scenes becomes an issue (for ex. with iPad)
         if let window = UIApplication.shared.windows.first(where: { window -> Bool in window.isKeyWindow}) {
             // Add modal view to the window to also cover tab bar

--- a/Flick/Models/Media.swift
+++ b/Flick/Models/Media.swift
@@ -10,6 +10,7 @@ import Foundation
 
 struct SimpleMedia: Codable {
     var id: Int
+    var title: String
     var posterPic: String?
 }
 

--- a/Flick/Networking/NetworkManager.swift
+++ b/Flick/Networking/NetworkManager.swift
@@ -85,13 +85,13 @@ class NetworkManager {
     }
 
     /// [POST] Create new list for a user with default/empty settings [updated as of 8/17/20]
-    static func createNewMediaList(listName: String, completion: @escaping (MediaList) -> Void) {
+    static func createNewMediaList(listName: String, mediaIds: [Int] = [], completion: @escaping (MediaList) -> Void) {
         let parameters: [String: Any] = [
             "name": listName,
             "is_favorite": true,
             "is_watched": true,
             "collaborators": [],
-            "shows": [],
+            "shows": mediaIds
         ]
 
         AF.request("\(hostEndpoint)/api/lsts/", method: .post,

--- a/Flick/Views/EnterListNameModalView.swift
+++ b/Flick/Views/EnterListNameModalView.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-protocol ListDelegate: class {
+protocol CreateListDelegate: class {
     func createList(title: String)
 }
 
@@ -25,8 +25,8 @@ class EnterListNameModalView: UIView {
     private let titleLabel = UILabel()
 
     // MARK: - Private Data Vars
+    weak var createListDelegate: CreateListDelegate?
     weak var modalDelegate: ModalDelegate?
-    weak var listDelegate: ListDelegate?
     weak var listSettingsDelegate: ListSettingsDelegate?
     private var type: EnterListNameModalType!
 
@@ -142,7 +142,7 @@ class EnterListNameModalView: UIView {
             self.modalDelegate?.dismissModal(modalView: self)
             switch self.type {
             case .createList:
-                self.listDelegate?.createList(title: nameText)
+                self.createListDelegate?.createList(title: nameText)
             case .renameList:
                 self.listSettingsDelegate?.renameList(to: nameText)
             case .none:

--- a/Flick/Views/MediaListsModalView.swift
+++ b/Flick/Views/MediaListsModalView.swift
@@ -106,6 +106,7 @@ class MediaListsModalView: UIView {
         getLists()
 
         if type == .saveMedia {
+            newListButton.addTarget(self, action: #selector(newListTapped), for: .touchUpInside)
             setupNewListButton()
         }
 
@@ -190,6 +191,11 @@ class MediaListsModalView: UIView {
                 self.saveMediaDelegate?.saveMedia(selectedList: selectedList)
             }
         }
+    }
+
+    @objc func newListTapped() {
+        self.modalDelegate?.dismissModal(modalView: self)
+        self.saveMediaDelegate?.presentCreateNewList()
     }
 
     required init?(coder: NSCoder) {

--- a/Flick/Views/MediaListsModalView.swift
+++ b/Flick/Views/MediaListsModalView.swift
@@ -62,8 +62,9 @@ class MediaListsModalView: UIView {
     private var selectedList: SimpleMediaList?
     private var type: MediaListsModalViewType
 
-    weak var modalDelegate: ModalDelegate?
     weak var editListDelegate: EditListDelegate?
+    weak var modalDelegate: ModalDelegate?
+    weak var saveMediaDelegate: SaveMediaDelegate?
 
     init(type: MediaListsModalViewType) {
         self.type = type
@@ -185,7 +186,8 @@ class MediaListsModalView: UIView {
                 guard let selectedList = self.selectedList else { return }
                 self.editListDelegate?.moveMedia(selectedList: selectedList)
             case .saveMedia:
-                break
+                guard let selectedList = self.selectedList else { return }
+                self.saveMediaDelegate?.saveMedia(selectedList: selectedList)
             }
         }
     }


### PR DESCRIPTION
### Overview 
Integrate save media to list backend


### Changes Made
- Save a media to a selected list
- Tapping on `New List` button brings to create new list modal and create new list with the media added

### Related Issues
#65 

### Screenshots/GIFs
<!-- Example: <img width="377" alt="NAME" src="LINK"> -->
