### PR TITLE
Fix cell image getting reused by other cells and miscellaneous fixes

### DIFF
--- a/Flick.xcodeproj/project.pbxproj
+++ b/Flick.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		803E5EF3259C05F5004CF4B7 /* ShareMediaModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803E5EF2259C05F5004CF4B7 /* ShareMediaModalView.swift */; };
 		803E5EF8259C0E7B004CF4B7 /* FlickToFriendModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803E5EF7259C0E7B004CF4B7 /* FlickToFriendModalView.swift */; };
 		803E5F0B259D41B5004CF4B7 /* Suggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803E5F0A259D41B4004CF4B7 /* Suggestion.swift */; };
+		803E5F8225A6BFD4004CF4B7 /* UserPreviewCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803E5F8125A6BFD3004CF4B7 /* UserPreviewCollectionViewCell.swift */; };
 		80B3F9B624DF0D8D002891C4 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B3F9B524DF0D8D002891C4 /* UIViewController.swift */; };
 		80B3F9B824DF96BB002891C4 /* MediaListsModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B3F9B724DF96BB002891C4 /* MediaListsModalView.swift */; };
 		80B3F9BA24E24078002891C4 /* ListNameTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B3F9B924E24078002891C4 /* ListNameTableViewCell.swift */; };
@@ -145,6 +146,7 @@
 		803E5EF2259C05F5004CF4B7 /* ShareMediaModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareMediaModalView.swift; sourceTree = "<group>"; };
 		803E5EF7259C0E7B004CF4B7 /* FlickToFriendModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlickToFriendModalView.swift; sourceTree = "<group>"; };
 		803E5F0A259D41B4004CF4B7 /* Suggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Suggestion.swift; sourceTree = "<group>"; };
+		803E5F8125A6BFD3004CF4B7 /* UserPreviewCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPreviewCollectionViewCell.swift; sourceTree = "<group>"; };
 		80B3F9B524DF0D8D002891C4 /* UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		80B3F9B724DF96BB002891C4 /* MediaListsModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaListsModalView.swift; sourceTree = "<group>"; };
 		80B3F9B924E24078002891C4 /* ListNameTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListNameTableViewCell.swift; sourceTree = "<group>"; };
@@ -480,6 +482,7 @@
 				D425B99524ECDAC100FB13A5 /* MediaThoughtsTableViewCell.swift */,
 				802FBB7225015A9D0095B049 /* DiscoverSearchVCCollectionViewCell.swift */,
 				D40ED7D3259471D7004C2F2C /* TrendingContentCollectionViewCell.swift */,
+				803E5F8125A6BFD3004CF4B7 /* UserPreviewCollectionViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -801,6 +804,7 @@
 				D492727E24DE50A100FA5F2A /* NotificationsViewController.swift in Sources */,
 				D47866A3247C5805009E42FE /* User.swift in Sources */,
 				D40ED7CF25946CE9004C2F2C /* DiscoverContent.swift in Sources */,
+				803E5F8225A6BFD4004CF4B7 /* UserPreviewCollectionViewCell.swift in Sources */,
 				D45DC62F24B933B000838DBF /* MediaSummary.swift in Sources */,
 				3095FF08247B93D700F08C60 /* RoundTopView.swift in Sources */,
 				80F00F7824BA50920051B8FF /* ConfirmationModalView.swift in Sources */,

--- a/Flick/Cells/CollaboratorTableViewCell.swift
+++ b/Flick/Cells/CollaboratorTableViewCell.swift
@@ -102,4 +102,9 @@ class CollaboratorTableViewCell: UITableViewCell {
         }
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        userImageView.image = nil
+    }
+
 }

--- a/Flick/Cells/CommentTableViewCell.swift
+++ b/Flick/Cells/CommentTableViewCell.swift
@@ -158,4 +158,10 @@ class CommentTableViewCell: UITableViewCell {
         }
         viewSpoilerButton.isHidden = !comment.isSpoiler || !hideSpoiler
     }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        profileImageView.image = nil
+    }
+
 }

--- a/Flick/Cells/DiscoverSearchResultTableViewCell.swift
+++ b/Flick/Cells/DiscoverSearchResultTableViewCell.swift
@@ -179,4 +179,10 @@ class DiscoverSearchResultTableViewCell: UITableViewCell {
             remake.centerY.equalToSuperview()
         }
     }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        resultImageView.image = nil
+    }
+
 }

--- a/Flick/Cells/FriendRequestTableViewCell.swift
+++ b/Flick/Cells/FriendRequestTableViewCell.swift
@@ -119,4 +119,10 @@ class FriendRequestTableViewCell: UITableViewCell {
                 break
             }
         }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        profileImageView.image = nil
+    }
+
 }

--- a/Flick/Cells/MediaInListCollectionViewCell.swift
+++ b/Flick/Cells/MediaInListCollectionViewCell.swift
@@ -36,4 +36,9 @@ class MediaInListCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        mediaImageView.image = nil
+    }
+
 }

--- a/Flick/Cells/MediaSearchResultTableViewCell.swift
+++ b/Flick/Cells/MediaSearchResultTableViewCell.swift
@@ -32,6 +32,8 @@ class MediaSearchResultTableViewCell: UITableViewCell {
 
         nameLabel.textColor = .darkBlue
         nameLabel.font = .systemFont(ofSize: 16)
+        nameLabel.adjustsFontSizeToFitWidth = true
+        nameLabel.minimumScaleFactor = 0.75
         containerView.addSubview(nameLabel)
 
         containerView.addSubview(selectView)
@@ -57,6 +59,7 @@ class MediaSearchResultTableViewCell: UITableViewCell {
         nameLabel.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.leading.equalTo(posterImageView.snp.trailing).offset(16)
+            make.trailing.equalTo(selectView.snp.leading).offset(-10)
         }
 
         selectView.snp.makeConstraints { make in

--- a/Flick/Cells/MediaSearchResultTableViewCell.swift
+++ b/Flick/Cells/MediaSearchResultTableViewCell.swift
@@ -89,4 +89,9 @@ class MediaSearchResultTableViewCell: UITableViewCell {
         }
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        posterImageView.image = nil
+    }
+
 }

--- a/Flick/Cells/MediaSelectableCollectionViewCell.swift
+++ b/Flick/Cells/MediaSelectableCollectionViewCell.swift
@@ -77,4 +77,10 @@ class MediaSelectableCollectionViewCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        posterImageView.image = nil
+    }
+
 }

--- a/Flick/Cells/MediaThoughtsTableViewCell.swift
+++ b/Flick/Cells/MediaThoughtsTableViewCell.swift
@@ -193,4 +193,9 @@ class MediaThoughtsTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        commentProfileImageView.image = nil
+    }
+
 }

--- a/Flick/Cells/NotificationTableViewCell.swift
+++ b/Flick/Cells/NotificationTableViewCell.swift
@@ -112,4 +112,9 @@ class NotificationTableViewCell: UITableViewCell {
         }
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        profileImageView.image = nil
+    }
+
 }

--- a/Flick/Cells/SuggestionTableViewCell.swift
+++ b/Flick/Cells/SuggestionTableViewCell.swift
@@ -203,5 +203,12 @@ class SuggestionTableViewCell: UITableViewCell {
 //        let heartImage = suggestion.liked ? "filledHeart" : "heart"
 //        likeButton.setImage(UIImage(named: heartImage), for: .normal)
     }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        profileImageView.image = nil
+        mediaImageView.image = nil
+    }
+
 }
 

--- a/Flick/Cells/TableViewCells/FriendTableViewCell.swift
+++ b/Flick/Cells/TableViewCells/FriendTableViewCell.swift
@@ -70,5 +70,10 @@ class FriendTableViewCell: UITableViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        userProfileImageView.image = nil
+    }
     
 }

--- a/Flick/Cells/TrendingContentCollectionViewCell.swift
+++ b/Flick/Cells/TrendingContentCollectionViewCell.swift
@@ -78,4 +78,9 @@ class TrendingContentCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageView.image = nil
+    }
+
 }

--- a/Flick/Cells/UserPreviewCollectionViewCell.swift
+++ b/Flick/Cells/UserPreviewCollectionViewCell.swift
@@ -1,0 +1,52 @@
+//
+//  UserPreviewCollectionViewCell.swift
+//  Flick
+//
+//  Created by Haiying W on 1/6/21.
+//  Copyright © 2021 flick. All rights reserved.
+//
+
+import UIKit
+
+class UserPreviewCollectionViewCell: UICollectionViewCell {
+
+    // MARK: - Private View Vars
+    private let profileImageView = UIImageView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = .deepPurple
+        clipsToBounds = true
+        layer.borderColor = UIColor.white.cgColor
+        layer.borderWidth = 0.5
+        layer.cornerRadius = 10
+
+        contentView.addSubview(profileImageView)
+
+        profileImageView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+
+    func configure(user: UserProfile?, shouldShowEllipsis: Bool) {
+        if shouldShowEllipsis {
+            profileImageView.image = UIImage(named: "ellipsis")
+        } else {
+            if let user = user,
+               let pictureUrl = URL(string: user.profilePic?.assetUrls.small ?? "") {
+                profileImageView.kf.setImage(with: pictureUrl)
+            }
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        profileImageView.image = nil
+    }
+
+}

--- a/Flick/Controllers/EditListViewController.swift
+++ b/Flick/Controllers/EditListViewController.swift
@@ -304,8 +304,15 @@ extension EditListViewController: EditListDelegate {
             guard let self = self else { return }
 
             self.presentInfoAlert(message: "Moved \(self.selectedMedia.count) items to \(selectedList.name)", completion: nil)
-            self.mediaCollectionView.reloadData()
             self.selectedMedia = []
+        }
+
+        NetworkManager.removeFromMediaList(listId: list.id, mediaIds: mediaIds) { [weak self] list in
+            guard let self = self else { return }
+
+            self.list = list
+            self.media = list.shows
+            self.mediaCollectionView.reloadData()
         }
     }
 

--- a/Flick/Views/UsersPreviewView.swift
+++ b/Flick/Views/UsersPreviewView.swift
@@ -55,7 +55,7 @@ class UsersPreviewView: UIView {
         usersCollectionView = UICollectionView(frame: .zero, collectionViewLayout: usersLayout)
         usersCollectionView.delegate = self
         usersCollectionView.dataSource = self
-        usersCollectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: usersCellReuseIdentifier)
+        usersCollectionView.register(UserPreviewCollectionViewCell.self, forCellWithReuseIdentifier: usersCellReuseIdentifier)
         usersCollectionView.backgroundColor = .none
         addSubview(usersCollectionView)
 
@@ -121,13 +121,7 @@ extension UsersPreviewView: UICollectionViewDelegate, UICollectionViewDataSource
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: usersCellReuseIdentifier, for: indexPath)
-//        let user = users[indexPath.item]
-        cell.backgroundColor = .deepPurple
-        cell.clipsToBounds = true
-        cell.layer.borderColor = UIColor.white.cgColor
-        cell.layer.borderWidth = 0.5
-        cell.layer.cornerRadius = 10
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: usersCellReuseIdentifier, for: indexPath) as? UserPreviewCollectionViewCell else { return UICollectionViewCell() }
 
         var shouldShowEllipsis: Bool {
             switch usersLayoutMode {
@@ -139,14 +133,11 @@ extension UsersPreviewView: UICollectionViewDelegate, UICollectionViewDataSource
         }
 
         if shouldShowEllipsis {
-            cell.backgroundView = UIImageView(image: UIImage(named: "ellipsis"))
+            cell.configure(user: nil, shouldShowEllipsis: true)
         } else {
-            let user = users[indexPath.item]
-            if let pictureUrl = URL(string: user.profilePic?.assetUrls.small ?? ""), let pictureData = try? Data(contentsOf: pictureUrl) {
-                let pictureObject = UIImage(data: pictureData)
-                cell.backgroundView = UIImageView(image: pictureObject)
-            }
+            cell.configure(user: users[indexPath.row], shouldShowEllipsis: false)
         }
+
         return cell
     }
 


### PR DESCRIPTION
### Overview 
Fix cell image getting reused by other cells and miscellaneous fixes

### Changes Made
- override`prepareForReuses` to cells with images so image cleared when reused
- make sure using move in edit list also removed shows from current list

### Related Issues
#77 

### Screenshots/GIFs
<!-- Example: <img width="377" alt="NAME" src="LINK"> -->
