### PR TITLE
Fix nav bar colors and double check shadows

### DIFF
--- a/Flick/Cells/TagCollectionViewCell.swift
+++ b/Flick/Cells/TagCollectionViewCell.swift
@@ -35,7 +35,7 @@ class TagCollectionViewCell: UICollectionViewCell {
         super.init(frame: frame)
         clipsToBounds = false
         layer.cornerRadius = 12
-        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowColor = UIColor.blueGrayShadow.cgColor
 
         tagLabel.textAlignment = .center
         tagLabel.font = .systemFont(ofSize: 12)

--- a/Flick/Controllers/AllNotificationsViewController.swift
+++ b/Flick/Controllers/AllNotificationsViewController.swift
@@ -45,7 +45,6 @@ class AllNotificationsViewController: UIViewController {
         tabCollectionView.backgroundColor = .movieWhite
         tabCollectionView.clipsToBounds = false
         tabCollectionView.layer.masksToBounds = false
-        // TODO: Double check tab bar shadows
         tabCollectionView.layer.shadowColor = UIColor.blueGrayShadow.cgColor
         tabCollectionView.layer.shadowOpacity = 0.07
         tabCollectionView.layer.shadowOffset = .init(width: 0, height: 4)

--- a/Flick/Controllers/EditProfileViewController.swift
+++ b/Flick/Controllers/EditProfileViewController.swift
@@ -99,11 +99,10 @@ class EditProfileViewController: UIViewController {
         selectImageButton.setImage(UIImage(named: "editButton"), for: .normal)
         selectImageButton.clipsToBounds = false
         selectImageButton.layer.masksToBounds = false
-        // TODO: Double check shadows
         selectImageButton.layer.shadowColor = UIColor.blueGrayShadow.cgColor
         selectImageButton.layer.shadowOpacity = 0.07
-        selectImageButton.layer.shadowOffset = .init(width: 0, height: 4)
-        selectImageButton.layer.shadowRadius = 8
+        selectImageButton.layer.shadowOffset = .init(width: 0, height: 1)
+        selectImageButton.layer.shadowRadius = 4
         view.addSubview(selectImageButton)
 
         firstNameFieldLabel.text = "First Name"
@@ -224,7 +223,6 @@ class EditProfileViewController: UIViewController {
         headerView.backgroundColor = .movieWhite
         headerView.clipsToBounds = false
         headerView.layer.masksToBounds = false
-        // TODO: Double check tab bar shadows
         headerView.layer.shadowColor = UIColor.blueGrayShadow.cgColor
         headerView.layer.shadowOpacity = 0.07
         headerView.layer.shadowOffset = .init(width: 0, height: 4)

--- a/Flick/Controllers/FriendsViewController.swift
+++ b/Flick/Controllers/FriendsViewController.swift
@@ -63,7 +63,6 @@ class FriendsViewController: UIViewController {
         headerView.backgroundColor = .movieWhite
         headerView.clipsToBounds = false
         headerView.layer.masksToBounds = false
-        // TODO: Double check tab bar shadows
         headerView.layer.shadowColor = UIColor.blueGrayShadow.cgColor
         headerView.layer.shadowOpacity = 0.07
         headerView.layer.shadowOffset = .init(width: 0, height: 4)

--- a/Flick/Controllers/HomeViewController.swift
+++ b/Flick/Controllers/HomeViewController.swift
@@ -52,11 +52,10 @@ class HomeViewController: UIViewController {
         tabCollectionView.layer.cornerRadius = 24
         // Apply corner radius only to bottom left and bottom right corners
         tabCollectionView.layer.maskedCorners = [.layerMaxXMaxYCorner, .layerMinXMaxYCorner]
-        // TODO: Fix tab bar shadows
-        tabCollectionView.layer.shadowColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.25).cgColor
-        tabCollectionView.layer.shadowOffset = CGSize(width: 4.0, height: 8.0)
+        tabCollectionView.layer.shadowColor = UIColor.blueGrayShadow.cgColor
+        tabCollectionView.layer.shadowOffset = CGSize(width: 0, height: 4)
         tabCollectionView.layer.shadowOpacity = 0.07
-        tabCollectionView.layer.shadowRadius = 4.0
+        tabCollectionView.layer.shadowRadius = 8
         view.addSubview(tabCollectionView)
 
         setUpConstraints()

--- a/Flick/Controllers/MediaViewController.swift
+++ b/Flick/Controllers/MediaViewController.swift
@@ -79,6 +79,11 @@ class MediaViewController: UIViewController {
         navigationController?.setNavigationBarHidden(false, animated: false)
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.navigationBar.setBackgroundImage(nil, for: UIBarMetrics.default)
+    }
+
     private func setupNavigationBar() {
         let backButtonSize = CGSize(width: 22, height: 18)
 

--- a/Flick/Controllers/SettingsViewController.swift
+++ b/Flick/Controllers/SettingsViewController.swift
@@ -128,7 +128,6 @@ class SettingsViewController: UIViewController {
         headerView.backgroundColor = .movieWhite
         headerView.clipsToBounds = false
         headerView.layer.masksToBounds = false
-        // TODO: Double check tab bar shadows
         headerView.layer.shadowColor = UIColor.blueGrayShadow.cgColor
         headerView.layer.shadowOpacity = 0.07
         headerView.layer.shadowOffset = .init(width: 0, height: 4)

--- a/Flick/Views/ModalViews/ProfileSelectionModalView.swift
+++ b/Flick/Views/ModalViews/ProfileSelectionModalView.swift
@@ -32,11 +32,10 @@ class ProfileSelectionModalView: UIView {
 
         containerView.backgroundColor = .movieWhite
         containerView.layer.cornerRadius = 24
-        // TODO: Double check shadows
         containerView.layer.shadowColor = UIColor.blueGrayShadow.cgColor
         containerView.layer.shadowOpacity = 0.07
-        containerView.layer.shadowOffset = .init(width: 0, height: 4)
-        containerView.layer.shadowRadius = 8
+        containerView.layer.shadowOffset = .init(width: 0, height: 2)
+        containerView.layer.shadowRadius = 20
         
         addSubview(containerView)
 

--- a/Flick/Views/PrivacySwitch.swift
+++ b/Flick/Views/PrivacySwitch.swift
@@ -41,10 +41,10 @@ class PrivacySwitch: UIButton {
 
         backgroundColor = .white
         layer.cornerRadius = 14
-        layer.shadowColor = UIColor.black.cgColor
-        layer.shadowOpacity = 0.1
-        layer.shadowRadius = 4
+        layer.shadowColor = UIColor.blueGrayShadow.cgColor
         layer.shadowOffset = CGSize(width: 0, height: 2)
+        layer.shadowOpacity = 0.29
+        layer.shadowRadius = 4
         layer.masksToBounds = false
 
         setupViews()

--- a/Flick/Views/RoundTopView.swift
+++ b/Flick/Views/RoundTopView.swift
@@ -19,9 +19,9 @@ class RoundTopView: UIView {
         layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
 
         if hasShadow {
-            layer.shadowColor = UIColor.black.cgColor
+            layer.shadowColor = UIColor.blueGrayShadow.cgColor
             layer.shadowOffset = CGSize(width: 0, height: -4)
-            layer.shadowOpacity = 0.1
+            layer.shadowOpacity = 0.07
             layer.shadowRadius = 8
         }
     }


### PR DESCRIPTION
### Overview 
- Fix nav bar colors (so the problem appears to be whenever we go to a media screen, the nav bar background get set to UIImage() so nav bar for other screens got messed up. so just gotta make sure background got reset when media screen disappear)
- Doubled checked all shadows we have with figma
### Changes Made


### Related Issues


### Screenshots/GIFs
<!-- Example: <img width="377" alt="NAME" src="LINK"> -->
