### PR TITLE
Add spinners, integrate quick add backend, truncate dateReleased

### DIFF
--- a/Flick/Cells/DiscoverSearchResultTableViewCell.swift
+++ b/Flick/Cells/DiscoverSearchResultTableViewCell.swift
@@ -87,7 +87,9 @@ class DiscoverSearchResultTableViewCell: UITableViewCell {
 
     func configureMovie(movie: Media) {
         titleLabel.text = movie.title
-        subtitleLabel.text = movie.dateReleased ?? ""
+        if let dateReleased = movie.dateReleased {
+            subtitleLabel.text = String(dateReleased.prefix(4))
+        }
         subtitleStackView.isHidden = false
         resultImageView.layer.cornerRadius = 4
         resultImageView.isHidden = false
@@ -121,7 +123,9 @@ class DiscoverSearchResultTableViewCell: UITableViewCell {
     func configureShow(show: Media) {
         titleLabel.text = show.title
         subtitleStackView.isHidden = false
-        subtitleLabel.text = show.dateReleased ?? ""
+        if let dateReleased = show.dateReleased {
+            subtitleLabel.text = String(dateReleased.prefix(4))
+        }
         resultImageView.layer.cornerRadius = 4
         resultImageView.isHidden = false
         updateConstraintsForPoster()

--- a/Flick/Cells/EditUserTableViewCell.swift
+++ b/Flick/Cells/EditUserTableViewCell.swift
@@ -74,8 +74,9 @@ class EditUserTableViewCell: UITableViewCell {
             editButton.backgroundColor = .clear
             editButton.setTitle("Added", for: .normal)
             editButton.layer.borderWidth = 0
+            editButton.titleEdgeInsets.right = 0
             editButton.snp.updateConstraints { update in
-                update.width.equalTo(68)
+                update.width.equalTo(58)
             }
         } else {
             editButton.isEnabled = true
@@ -83,6 +84,7 @@ class EditUserTableViewCell: UITableViewCell {
             editButton.setTitle("Add", for: .normal)
             editButton.layer.borderWidth = 1
             editButton.layer.borderColor = UIColor.darkBlueGray2.cgColor
+            editButton.titleEdgeInsets.right = 10
             editButton.snp.updateConstraints { update in
                 update.width.equalTo(48)
             }

--- a/Flick/Cells/SuggestionTableViewCell.swift
+++ b/Flick/Cells/SuggestionTableViewCell.swift
@@ -220,7 +220,9 @@ class SuggestionTableViewCell: UITableViewCell {
             tagsLabel.text = tags.joined(separator: ", ")
         }
         movieIconImageView.image = UIImage(named: suggestion.show.isTv ? "tv" : "film")
-        releaseDateLabel.text = suggestion.show.dateReleased
+        if let dateReleased = suggestion.show.dateReleased {
+            releaseDateLabel.text = String(dateReleased.prefix(4))
+        }
         synopsisLabel.text = suggestion.show.plot
         let dateLabelText = Date().getDateLabelText(createdAt: suggestion.createdAt)
         dateLabel.text = dateLabelText

--- a/Flick/Controllers/AddMediaViewController.swift
+++ b/Flick/Controllers/AddMediaViewController.swift
@@ -320,7 +320,12 @@ class AddMediaViewController: UIViewController {
     }
 
     @objc private func quickAddTapped() {
-        print("Quick add tapped")
+        guard type == .toGroup,
+              let groupId = groupId else { return }
+        NetworkManager.addToGroup(id: groupId, isQuickAdd: true) { [weak self] _ in
+            guard let self = self else { return }
+            self.dismissVC(isMediaAdded: true)
+        }
     }
 
     @objc private func handleDragToDismiss(sender: UIPanGestureRecognizer) {

--- a/Flick/Controllers/MediaCardVewController.swift
+++ b/Flick/Controllers/MediaCardVewController.swift
@@ -17,6 +17,7 @@ class MediaCardViewController: UIViewController {
     // MARK: - Private View Vars
     private let commentAreaView = CommentAreaView()
     private let handleIndicatorView = UIView()
+    private let spinner = UIActivityIndicatorView(style: .medium)
 
     // MARK: - Private Data Vars
     private let handleIndicatorViewSize = CGSize(width: 64, height: 5)
@@ -53,6 +54,9 @@ class MediaCardViewController: UIViewController {
         mediaInformationTableView.register(MediaRatingsTableViewCell.self, forCellReuseIdentifier: mediaRatingsReuseIdentifier)
         mediaInformationTableView.register(MediaThoughtsTableViewCell.self, forCellReuseIdentifier: mediaThoughtsReuseIdentifier)
         view.addSubview(mediaInformationTableView)
+
+        view.addSubview(spinner)
+        spinner.startAnimating()
 
         commentAreaView.delegate = self
         commentAreaView.sizeToFit()
@@ -94,6 +98,11 @@ class MediaCardViewController: UIViewController {
             make.leading.trailing.equalToSuperview()
             make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
         }
+
+        spinner.snp.makeConstraints { make in
+            make.top.equalTo(handleArea.snp.bottom).offset(30)
+            make.centerX.equalToSuperview()
+        }
     }
 
     // TODO: Fix scrolling and card pan gesture interactions
@@ -105,6 +114,7 @@ class MediaCardViewController: UIViewController {
         self.media = media
         mediaInformationTableView.reloadData()
         mediaInformationTableView.isHidden = false
+        spinner.stopAnimating()
     }
 
 }

--- a/Flick/Controllers/MediaCommentsViewController.swift
+++ b/Flick/Controllers/MediaCommentsViewController.swift
@@ -52,6 +52,7 @@ class MediaCommentsViewController: UIViewController {
         commentsTableView.estimatedRowHeight = 140
         commentsTableView.sizeToFit()
         commentsTableView.keyboardDismissMode = .interactive
+        commentsTableView.showsVerticalScrollIndicator = false
         view.addSubview(commentsTableView)
 
         setupConstraints()

--- a/Flick/Controllers/MediaViewController.swift
+++ b/Flick/Controllers/MediaViewController.swift
@@ -139,7 +139,9 @@ class MediaViewController: UIViewController {
         NetworkManager.getMedia(mediaId: mediaId) { [weak self] media in
             guard let self = self else { return }
             self.media = media
-            self.mediaCardViewController.setupMedia(media: media)
+            DispatchQueue.main.async {
+                self.mediaCardViewController.setupMedia(media: media)
+            }
         }
     }
 

--- a/Flick/Group/GroupVoteViewController.swift
+++ b/Flick/Group/GroupVoteViewController.swift
@@ -22,6 +22,7 @@ class GroupVoteViewController: UIViewController {
     private let noIdeasLabel = UILabel()
     private let numIdeasLabel = UILabel()
     private let posterImageView = UIImageView()
+    private let spinner = UIActivityIndicatorView(style: .medium)
     private let voteMaybeButton = UIButton()
     private let voteNoButton = UIButton()
     private let voteYesButton = UIButton()
@@ -139,6 +140,10 @@ class GroupVoteViewController: UIViewController {
         voteYesButton.addTarget(self, action: #selector(voteYesButtonPressed), for: .touchUpInside)
         view.addSubview(voteYesButton)
 
+        spinner.hidesWhenStopped = true
+        view.addSubview(spinner)
+        spinner.startAnimating()
+
         setupConstraints()
     }
 
@@ -168,6 +173,10 @@ class GroupVoteViewController: UIViewController {
             make.top.equalTo(numIdeasLabel.snp.bottom).offset(12)
             make.bottom.equalTo(voteMaybeButton.snp.top).offset(-16)
             make.leading.trailing.equalToSuperview().inset(38)
+        }
+
+        spinner.snp.makeConstraints { make in
+            make.center.equalTo(posterImageView)
         }
 
         mediaInformationTableView.snp.makeConstraints { make in
@@ -247,6 +256,7 @@ class GroupVoteViewController: UIViewController {
                 if timestamp.iso8601withFractionalSeconds ?? Date() >= self.lastRequestTime ?? Date() {
                     self.ideas = ideas
                 }
+                self.spinner.stopAnimating()
             }
         }
     }

--- a/Flick/Group/GroupsViewController.swift
+++ b/Flick/Group/GroupsViewController.swift
@@ -15,6 +15,7 @@ class GroupsViewController: UIViewController {
     private let emptyStateView = EmptyStateView(type: .group)
     private let groupsTableView = UITableView(frame: .zero, style: .grouped)
     private let refreshControl = UIRefreshControl()
+    private let spinner = UIActivityIndicatorView(style: .large)
 
     // MARK: - Private View Vars
     private var groups: [Group] = []
@@ -48,6 +49,9 @@ class GroupsViewController: UIViewController {
         emptyStateView.isHidden = true
         view.addSubview(emptyStateView)
 
+        view.addSubview(spinner)
+        spinner.startAnimating()
+
         groupsTableView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
@@ -62,6 +66,10 @@ class GroupsViewController: UIViewController {
             make.top.equalToSuperview().offset(200)
             make.centerX.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(50)
+        }
+
+        spinner.snp.makeConstraints { make in
+            make.center.equalToSuperview()
         }
     }
 
@@ -94,6 +102,7 @@ class GroupsViewController: UIViewController {
                 self.emptyStateView.isHidden = groups.count > 0
                 self.groupsTableView.reloadData()
                 self.refreshControl.endRefreshing()
+                self.spinner.stopAnimating()
             }
         }
     }

--- a/Flick/Networking/NetworkManager.swift
+++ b/Flick/Networking/NetworkManager.swift
@@ -873,10 +873,11 @@ class NetworkManager {
     }
 
     /// [POST] Add  to group [updated as of 1/29/21]
-    static func addToGroup(id: Int, memberIds: [Int] = [], mediaIds: [Int] = [], completion: @escaping (Group) -> Void) {
+    static func addToGroup(id: Int, memberIds: [Int] = [], mediaIds: [Int] = [], isQuickAdd: Bool = false, completion: @escaping (Group) -> Void) {
         let parameters: [String: Any] = [
             "members": memberIds,
-            "shows": mediaIds
+            "shows": mediaIds,
+            "num_random_shows": isQuickAdd ? 5: 0
         ]
 
         AF.request("\(hostEndpoint)/api/groups/\(id)/add/", method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers).validate().responseData { response in

--- a/Flick/Notifications/ActivityViewController.swift
+++ b/Flick/Notifications/ActivityViewController.swift
@@ -14,6 +14,7 @@ class ActivityViewController: UIViewController {
     private let activityTableView = UITableView(frame: .zero, style: .grouped)
     private let emptyStateView = EmptyStateView(type: .activity)
     private let refreshControl = UIRefreshControl()
+    private let spinner = UIActivityIndicatorView(style: .large)
 
     // MARK: - Private Data Vars
     private var friendRequests: [NotificationEnum] = []
@@ -49,6 +50,9 @@ class ActivityViewController: UIViewController {
         
         emptyStateView.isHidden = true
         view.addSubview(emptyStateView)
+
+        view.addSubview(spinner)
+        spinner.startAnimating()
     
         setupConstraints()
     }
@@ -62,6 +66,10 @@ class ActivityViewController: UIViewController {
         emptyStateView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(150)
             make.centerX.equalToSuperview()
+        }
+
+        spinner.snp.makeConstraints { make in
+            make.center.equalToSuperview()
         }
     }
     
@@ -80,6 +88,7 @@ class ActivityViewController: UIViewController {
                 self.activityTableView.reloadData()
                 self.updateNotificationViewedTime()
                 self.refreshControl.endRefreshing()
+                self.spinner.stopAnimating()
             }
         }
     }

--- a/Flick/Notifications/SuggestionsViewController.swift
+++ b/Flick/Notifications/SuggestionsViewController.swift
@@ -14,6 +14,7 @@ class SuggestionsViewController: UIViewController {
     private let emptyStateView = EmptyStateView(type: .suggestions)
     private let suggestionsTableView = UITableView(frame: .zero)
     private let refreshControl = UIRefreshControl()
+    private let spinner = UIActivityIndicatorView(style: .large)
     
     // MARK: - Private Data Vars
     private var suggestions: [Suggestion] = []
@@ -47,6 +48,9 @@ class SuggestionsViewController: UIViewController {
         
         emptyStateView.isHidden = true
         view.addSubview(emptyStateView)
+
+        view.addSubview(spinner)
+        spinner.startAnimating()
         
         setupConstraints()
     }
@@ -59,6 +63,10 @@ class SuggestionsViewController: UIViewController {
         emptyStateView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(150)
             make.centerX.equalToSuperview()
+        }
+
+        spinner.snp.makeConstraints { make in
+            make.center.equalToSuperview()
         }
     }
     
@@ -80,6 +88,7 @@ class SuggestionsViewController: UIViewController {
                 self.suggestionsTableView.reloadData()
                 self.updateSuggestionViewedTime()
                 self.refreshControl.endRefreshing()
+                self.spinner.stopAnimating()
             }
         }
     }

--- a/Flick/Views/ModalViews/SuggestToFriendModalView.swift
+++ b/Flick/Views/ModalViews/SuggestToFriendModalView.swift
@@ -52,8 +52,10 @@ class SuggestToFriendModalView: ModalView {
         mediaIconImageView.image = UIImage(named: media.isTv ? "tv" : "film")
         containerView.addSubview(mediaIconImageView)
 
-        if let duration = media.duration?.inHourMinute, let dateReleased = media.dateReleased {
-            mediaInfoLabel.text = "\(duration) • \(dateReleased)"
+        if let duration = media.duration?.inHourMinute,
+           let dateReleased = media.dateReleased {
+            let releaseYear = String(dateReleased.prefix(4))
+            mediaInfoLabel.text = "\(duration) • \(releaseYear)"
         }
         mediaInfoLabel.textColor = .mediumGray
         mediaInfoLabel.font = .systemFont(ofSize: 12)


### PR DESCRIPTION
### Overview 
- Add spinners to media, list, groups, activity, suggestions, loading ideas when voting
- integrate quick add backend for groups 
- truncate dateReleased to just the year
- aligned add and added buttons more for EditUserTVC

### Changes Made


### Related Issues


### Screenshots/GIFs
<!-- Example: <img width="377" alt="NAME" src="LINK"> -->
<img width="256" alt="Screen Shot 2021-02-20 at 1 04 23 PM" src="https://user-images.githubusercontent.com/48968041/108604521-6a361400-737c-11eb-9db0-48c02d4788bd.png">

some spinners
![Simulator Screen Shot - iPhone 12 - 2021-02-20 at 14 57 37](https://user-images.githubusercontent.com/48968041/108607062-04ea1f00-738c-11eb-8408-c350ef1f8b93.png)
![Simulator Screen Shot - iPhone 12 - 2021-02-20 at 14 57 32](https://user-images.githubusercontent.com/48968041/108607068-087da600-738c-11eb-87f4-24cf3f136f89.png)
